### PR TITLE
try to fix CI, a pytest API change broke it

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1001
+  number: 1002
   script: python setup.py install --single-version-externally-managed --record record.txt
   skip: True  # [win]
 
@@ -48,7 +48,8 @@ test:
     - click  # [not osx]
     - netcdf4  # [not osx]
     - responses
-    - pytest
+    # see https://docs.pytest.org/en/latest/changelog.html#removals
+    - pytest <5.1.0
     - pytest-xdist
     - mock  # [py27]
     - futures  # [py27]


### PR DESCRIPTION
conda-forge#14 got merged with broken CI, so one single package got deployed but most didnt

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
